### PR TITLE
Add Fates' proposal for landmarks

### DIFF
--- a/lore/master-codes.md
+++ b/lore/master-codes.md
@@ -1,0 +1,61 @@
+---
+title: "Concept: Landmarks and Master Codes"
+---
+# Master Codes
+
+Master Codes are the relics of a time long gone but they still hold much of the power they contained when they were first made.
+The powers the Master Codes bequeath unto its holder vary from Master Code to Master Code ranging from Manipulation of Nature to bending light into a sword,
+the cost at using the Master Codes is heavy on the body and can lead to mental and physical deterioration, it is not known which comes first.
+
+These Master Codes represent the families of the Digital World (Jungle Troopers, Deep Savers, etc).
+Master Codes are vital to the Digital World and as such they have their own defence mechanism to help drive away any who would dare remove them from their designated areas by emitting an aura of fear and danger to ward them off.
+Removing a Master Code from its designated Landmark holds serious repercussions as it is the only thing keeping that Landmark in one piece as such the removal of a Master Code will warp and even destroy the Landmark it inhabits,
+to the point you can’t recognise the Landmark anymore.
+
+The Landmarks that the Master Codes inhabit vary from Code to Code but are always tied to the Family that the Master Code represents;
+for example the Jungle Trooper code is hidden within a jungle and the Dragons Roar code is hidden within a desolate volcano area.
+It is currently unknown where all the codes in the Digital World are and currently no known person is seeking them due to the ramifications removing them could have on the world. 
+
+No one knows for sure who created the Master Codes but legend say that they were made to seal away a Anti-Virus Software that went rogue,
+labelling all digimon as Virus types and attempted to destroy and consume all digimon,
+in the end it was sealed away but not before it could consume most of the Digimon of the Server. 
+
+# Landmarks
+
+The Landmarks that house the Master Codes are varied but are always related to the Family connection of the code that resides within them.
+Islands will only ever have two Master Codes per Island. 
+
+* Nature Spirits (monsters and beasts)
+  * Grasslands
+  * Canyons
+
+* Deep Savers	(Aquatic or ice-related Digimon. )
+  * Oceans
+  * Lakes
+  * Arctic
+  * Marsh/Swamp
+
+* Nightmare Soldiers (Darkness or spirit based Digimon, or Digimon based on traditional "Halloween" monsters like vampires, werewolves, or Japanese youkai and demons.)
+  * Haunted Areas
+  * Dark Forests
+  * Abandoned Castles
+
+* Wind Guardians (Flying, air, or plant based Digimon.)
+  * Forests
+  * Sky
+
+* Metal Empire (Machine, cyborg, or other mechanical Digimon.)
+  * Factories
+  * Cities
+  * Scrap Yards
+
+* Virus Busters (Heroic or angelic Digimon, often includes main characters from the anime or manga) 
+  * Crys Sanctuary
+
+* Dragon's Roar	 (Draconic, reptile, or fire-related Digimon.)
+  * Volcanos
+  * Desert
+  * Mountains
+
+* Jungle Troopers (Plant or Insect based Digimon.)
+  * Jungles


### PR DESCRIPTION
Fates left, but the proposal is a good idea.

> My idea stems from a belief that giving Players the Digimemories or anything of the sort sets them up to be a substantial amount more important than other players and that can feel intimidating or demeaning to them… so what if Digimemories didn’t exist and instead were replaced by ‘Master Codes’ these codes would be tied to the Digimon families just like the Digimemories but instead of being an object that Digimon can keep on them and fuse with to get stronger they were just some code that fused to create a greater object.